### PR TITLE
fix: Reasoning collapse jank

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CHAT_MODEL: string = 'chat-model-small';
+export const DEFAULT_CHAT_MODEL: string = 'chat-model';
 
 interface ChatModel {
 	id: string;

--- a/src/lib/components/message-reasoning.svelte
+++ b/src/lib/components/message-reasoning.svelte
@@ -2,8 +2,23 @@
 	import LoaderIcon from './icons/loader.svelte';
 	import ChevronDownIcon from './icons/chevron-down.svelte';
 	import { Markdown } from './markdown';
+	import { slide } from 'svelte/transition';
+	import { cubicInOut } from 'svelte/easing';
+	import { getLock } from '$lib/hooks/lock';
+	import { tick } from 'svelte';
 	let { loading, reasoning }: { loading: boolean; reasoning: string } = $props();
 	let expanded = $state(false);
+	const scrollLock = getLock('messages-scroll');
+
+	function lockScrolling() {
+		scrollLock.locked = true;
+	}
+
+	function unlockScrolling() {
+		tick().then(() => {
+			scrollLock.locked = false;
+		});
+	}
 </script>
 
 <div class="flex flex-col">
@@ -30,5 +45,16 @@
 		</div>
 	{/if}
 
-	<Markdown md={reasoning} />
+	{#if expanded}
+		<div
+			transition:slide={{ duration: 200, easing: cubicInOut }}
+			onintrostart={lockScrolling}
+			onintroend={unlockScrolling}
+			onoutrostart={lockScrolling}
+			onoutroend={unlockScrolling}
+			class="mb-2 mt-4 flex flex-col gap-4 border-l pl-4 text-zinc-600 dark:text-zinc-400"
+		>
+			<Markdown md={reasoning} />
+		</div>
+	{/if}
 </div>

--- a/src/lib/components/messages.svelte
+++ b/src/lib/components/messages.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import PreviewMessage from './messages/preview-message.svelte';
 	import type { UIMessage } from '@ai-sdk/svelte';
+	import { getLock } from '$lib/hooks/lock';
 
 	let containerRef = $state<HTMLDivElement | null>(null);
 	let endRef = $state<HTMLDivElement | null>(null);
@@ -23,11 +24,13 @@
 		mounted = true;
 	});
 
+	const scrollLock = getLock('messages-scroll');
+
 	$effect(() => {
 		if (!(containerRef && endRef)) return;
 
 		const observer = new MutationObserver(() => {
-			if (!endRef) return;
+			if (!endRef || scrollLock.locked) return;
 			endRef.scrollIntoView({ behavior: 'instant', block: 'end' });
 		});
 

--- a/src/lib/hooks/lock.ts
+++ b/src/lib/hooks/lock.ts
@@ -1,0 +1,17 @@
+import { getContext, setContext } from 'svelte';
+
+export class Lock {
+	locked = false;
+}
+
+const lockKey = (key: string) => Symbol.for(`lock:${key}`);
+
+export function getLock(key: string): Lock {
+	const k = lockKey(key);
+	let lock = getContext<Lock>(k);
+	if (!lock) {
+		lock = new Lock();
+		setContext(k, lock);
+	}
+	return lock;
+}

--- a/src/routes/(chat)/+layout.server.ts
+++ b/src/routes/(chat)/+layout.server.ts
@@ -1,12 +1,12 @@
-import { DEFAULT_CHAT_MODEL } from '$lib/ai/models';
+import { chatModels, DEFAULT_CHAT_MODEL } from '$lib/ai/models';
 import { SelectedModel } from '$lib/hooks/selected-model.svelte.js';
 
 export async function load({ cookies, locals }) {
 	const { user } = locals;
 	const sidebarCollapsed = cookies.get('sidebar:state') !== 'true';
 
-	let modelId = cookies.get('modelId');
-	if (!modelId) {
+	let modelId = cookies.get('selected-model');
+	if (!modelId || !chatModels.find((model) => model.id === modelId)) {
 		modelId = DEFAULT_CHAT_MODEL;
 		cookies.set('selected-model', modelId, {
 			path: '/',


### PR DESCRIPTION
When expanding or collapsing reasoning from the chat, because it mutated the messages content, it would try to scroll to the bottom. This obviously isn't desirable behavior. This introduces a simple lock that's turned on while the transition is firing and removed one tick after it's done.